### PR TITLE
Jaxrs 0.6 servlet25compatible

### DIFF
--- a/src/groovy/org/grails/jaxrs/support/ConverterUtils.groovy
+++ b/src/groovy/org/grails/jaxrs/support/ConverterUtils.groovy
@@ -180,13 +180,13 @@ class ConverterUtils {
             
         });
     }
-	
-	/**
-	 * Interface used in order to expose properties dinamically added by grails (i.e. 'format added by RequestMimeTypesApi)
-	 * Without this some tests would fail. 
-	 */
-	interface EnhancedRequestProps {
-		String getFormat ();
-		void setFormat (String) 
-	}
+    
+    /**
+     * Interface used in order to expose properties dinamically added by grails (i.e. 'format added by RequestMimeTypesApi)
+     * Without this some tests would fail. 
+     */
+    interface EnhancedRequestProps {
+        String getFormat ();
+        void setFormat (String) 
+    }
 }


### PR DESCRIPTION
A patch to restore servlet 2.5 compatibility on grails-jaxrs 0.6 ( as per http://code.google.com/p/grails-jaxrs/issues/detail?id=66#c5 ).

It works fine for me on servlet 2.5 (Tomcat 6.0.33) and servlet 3.0 (Tomcat 7.0.29). I don't use new features introduced by servlet 3.0 api.
