### PR TITLE
Added support for handing different encodings specified in HTTP Headers

### DIFF
--- a/src/groovy/org/grails/jaxrs/support/ConverterUtils.groovy
+++ b/src/groovy/org/grails/jaxrs/support/ConverterUtils.groovy
@@ -19,11 +19,15 @@ import static org.codehaus.groovy.grails.web.converters.configuration.Converters
 
 import java.util.Map
 
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+
 import grails.converters.JSON
 import grails.converters.XML
 
 import groovy.util.slurpersupport.GPathResult
-import org.apache.commons.logging.*
+
+import org.apache.commons.logging.*
 
 import org.codehaus.groovy.grails.commons.GrailsApplication
 import org.codehaus.groovy.grails.web.converters.JSONParsingParameterCreationListener;
@@ -78,6 +82,30 @@ class ConverterUtils {
         }
         encoding
     }
+	
+	/** Extracts encoding from HTTP headers or MediaType parameters */
+	static String getEncoding(MultivaluedMap httpHeaders, MediaType mediaType, String defaultEncoding) {
+		println httpHeaders
+		// if HTTP headers specify the charset and this was parsed into the MediaType object, return the charset from MediaType
+		// Jersey parses http headers into MediaType object
+		if (mediaType.parameters['charset']) {
+			String encoding = mediaType.parameters['charset'];
+			return encoding
+		}
+		
+		// Restlet does not parse the headers into MediaType so we need to extract them manually
+		def contentTypeHeaderKey = httpHeaders.keySet().find { key -> key.toLowerCase() == 'content-type' }
+		if (contentTypeHeaderKey) {
+			String contentTypeHeaderValue = httpHeaders.getFirst(contentTypeHeaderKey)
+			if (contentTypeHeaderValue.contains('charset=')) {
+				String encoding = contentTypeHeaderValue.substring(contentTypeHeaderValue.indexOf('charset=') + 'charset='.length())
+				return encoding
+			}
+		}
+		
+		// no encoding specified
+		return defaultEncoding
+	}
     
     /**
      * Reads a JSON stream from <code>input</code> and converts it to a map

--- a/src/groovy/org/grails/jaxrs/support/DomainObjectReaderSupport.groovy
+++ b/src/groovy/org/grails/jaxrs/support/DomainObjectReaderSupport.groovy
@@ -86,15 +86,15 @@ abstract class DomainObjectReaderSupport implements MessageBodyReader<Object>, G
             Annotation[] annotations, MediaType mediaType,
             MultivaluedMap httpHeaders, InputStream entityStream)
         throws IOException, WebApplicationException {
-        
+
         if (isXmlType(mediaType)) {
-            return readFromXml(type, entityStream, getDefaultXMLEncoding(grailsApplication))
+            return readFromXml(type, entityStream, getEncoding(httpHeaders, mediaType, getDefaultXMLEncoding(grailsApplication)))
         } else { // JSON
-            return readFromJson(type, entityStream, getDefaultJSONEncoding(grailsApplication))
+            return readFromJson(type, entityStream, getEncoding(httpHeaders, mediaType, getDefaultJSONEncoding(grailsApplication)))
         }
-        
+
     }
-    
+
     /**
      * If <code>false</code> this reader will be skipped. Returns 
      * <code>true</code> by default.
@@ -121,7 +121,7 @@ abstract class DomainObjectReaderSupport implements MessageBodyReader<Object>, G
      * Construct domain object from json map obtained from entity stream.
      */
     protected Object readFromJson(Class type, InputStream entityStream, String charset) {
-        def map = jsonToMap(entityStream, charset) 
+        def map = jsonToMap(entityStream, charset)
         def result = type.metaClass.invokeConstructor(map)
 
         // Workaround for http://jira.codehaus.org/browse/GRAILS-1984

--- a/src/java/org/grails/jaxrs/provider/JSONReader.java
+++ b/src/java/org/grails/jaxrs/provider/JSONReader.java
@@ -20,15 +20,19 @@ import static org.grails.jaxrs.support.ConverterUtils.jsonToMap;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
 import java.util.Map;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.Provider;
 
 import org.codehaus.groovy.grails.commons.GrailsApplication;
 import org.codehaus.groovy.grails.plugins.support.aware.GrailsApplicationAware;
+import org.grails.jaxrs.support.ConverterUtils;
 import org.grails.jaxrs.support.MessageBodyReaderSupport;
 
 /**
@@ -78,14 +82,23 @@ public class JSONReader extends MessageBodyReaderSupport<Map> implements GrailsA
      * @return a map representation of the JSON request entity stream.
      */
     @Override
-    public Map readFrom(MultivaluedMap<String, String> httpHeaders, InputStream entityStream) 
-        throws IOException, WebApplicationException {
-        
-        // TODO: obtain encoding from HTTP header
-        String encoding = getDefaultEncoding(grailsApplication);
+    public Map readFrom(Class<Map> type, Type genericType,
+            Annotation[] annotations, MediaType mediaType,
+            MultivaluedMap<String, String> httpHeaders, InputStream entityStream)
+            throws IOException, WebApplicationException {
+    	
+    	String encoding = ConverterUtils.getEncoding(httpHeaders, mediaType, getDefaultEncoding(grailsApplication));
 
         // Convert JSON to map used for constructing domain objects
         return jsonToMap(entityStream, encoding);
     }
+
+	@Override
+	public Map readFrom(MultivaluedMap<String, String> httpHeaders,
+			InputStream entityStream) throws IOException,
+			WebApplicationException {
+		// TODO: Fix MessageBodyReaderSupport abstract method (remove it completely or add empty implementation?)
+		throw new RuntimeException("This should never be called, because we override the readFrom(all-parameters) method.");
+	}
 
 }

--- a/src/java/org/grails/jaxrs/provider/XMLReader.java
+++ b/src/java/org/grails/jaxrs/provider/XMLReader.java
@@ -16,19 +16,24 @@
 package org.grails.jaxrs.provider;
 
 import static org.grails.jaxrs.support.ConverterUtils.getDefaultEncoding;
+import static org.grails.jaxrs.support.ConverterUtils.jsonToMap;
 import static org.grails.jaxrs.support.ConverterUtils.xmlToMap;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
 import java.util.Map;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.Provider;
 
 import org.codehaus.groovy.grails.commons.GrailsApplication;
 import org.codehaus.groovy.grails.plugins.support.aware.GrailsApplicationAware;
+import org.grails.jaxrs.support.ConverterUtils;
 import org.grails.jaxrs.support.MessageBodyReaderSupport;
 
 /**
@@ -79,14 +84,23 @@ public class XMLReader extends MessageBodyReaderSupport<Map> implements GrailsAp
      * @see ConverterUtils#xmlToMap(InputStream, String)
      */
     @Override
-    public Map readFrom(MultivaluedMap<String, String> httpHeaders, InputStream entityStream) 
-        throws IOException, WebApplicationException {
-        
-        // TODO: obtain encoding from HTTP header and/or XML document
-        String encoding = getDefaultEncoding(grailsApplication);
+    public Map readFrom(Class<Map> type, Type genericType,
+            Annotation[] annotations, MediaType mediaType,
+            MultivaluedMap<String, String> httpHeaders, InputStream entityStream)
+            throws IOException, WebApplicationException {
+    	
+    	String encoding = ConverterUtils.getEncoding(httpHeaders, mediaType, getDefaultEncoding(grailsApplication));
 
-        // Convert XML to map used for constructing domain objects
-        return xmlToMap(entityStream, encoding);
+        // Convert JSON to map used for constructing domain objects
+		return xmlToMap(entityStream, encoding);
     }
 
+	@Override
+	public Map readFrom(MultivaluedMap<String, String> httpHeaders,
+			InputStream entityStream) throws IOException,
+			WebApplicationException {
+		// TODO: Fix MessageBodyReaderSupport abstract method 
+		throw new RuntimeException("This should never be called, because we override the readFrom(all-parameters) method.");
+	}
+	
 }


### PR DESCRIPTION
Hi,

I have implemented support for **handing charset encoding**, if specified in HTTP headers. I also added a few tests to verify this improvement and that pass succesfully.

The branch is 0.5m1 as I am currently using Grails 1.3.7 for my work.

Please take a look and contact me if you have any comments.

Notes:
As I am quite new to GIT, there are quite a few whitespace changes in one file that I accidentally added to the commit. I'm sure you can resolve this on your side.

Best regards,
Dumitru
