### PR TITLE
Encoding support for jaxrs 0.8

### DIFF
--- a/src/groovy/org/grails/jaxrs/support/DomainObjectReaderSupport.groovy
+++ b/src/groovy/org/grails/jaxrs/support/DomainObjectReaderSupport.groovy
@@ -77,9 +77,9 @@ abstract class DomainObjectReaderSupport implements MessageBodyReader<Object>, G
     throws IOException, WebApplicationException {
 
         if (isXmlType(mediaType)) {
-            return readFromXml(type, entityStream, getDefaultXMLEncoding(grailsApplication))
+            return readFromXml(type, entityStream, getEncoding(httpHeaders, mediaType, getDefaultXMLEncoding(grailsApplication)))
         } else { // JSON
-            return readFromJson(type, entityStream, getDefaultJSONEncoding(grailsApplication))
+            return readFromJson(type, entityStream, getEncoding(httpHeaders, mediaType, getDefaultJSONEncoding(grailsApplication)))
         }
 
     }

--- a/src/java/org/grails/jaxrs/provider/JSONReader.java
+++ b/src/java/org/grails/jaxrs/provider/JSONReader.java
@@ -20,15 +20,19 @@ import static org.grails.jaxrs.support.ConverterUtils.jsonToSimpleModel;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
 import java.util.Map;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.Provider;
 
 import org.codehaus.groovy.grails.commons.GrailsApplication;
 import org.codehaus.groovy.grails.plugins.support.aware.GrailsApplicationAware;
+import org.grails.jaxrs.support.ConverterUtils;
 import org.grails.jaxrs.support.MessageBodyReaderSupport;
 
 /**
@@ -68,21 +72,23 @@ public class JSONReader extends MessageBodyReaderSupport<Map> implements GrailsA
         this.grailsApplication = grailsApplication;
     }
 
-    /**
-     * Creates a map from a JSON request entity stream.
-     *
-     * @param httpHeaders  HTTP headers.
-     * @param entityStream JSON request entity stream.
-     * @return a map representation of the JSON request entity stream.
-     */
     @Override
-    public Map readFrom(MultivaluedMap<String, String> httpHeaders, InputStream entityStream)
+    public Map readFrom(Class<Map> type, Type genericType,
+            Annotation[] annotations, MediaType mediaType,
+            MultivaluedMap<String, String> httpHeaders, InputStream entityStream)
             throws IOException, WebApplicationException {
-
-        // TODO: obtain encoding from HTTP header
-        String encoding = getDefaultEncoding(grailsApplication);
+        
+        String encoding = ConverterUtils.getEncoding(httpHeaders, mediaType, getDefaultEncoding(grailsApplication));
 
         // Convert JSON to map used for constructing domain objects
         return jsonToSimpleModel(entityStream, encoding);
+    }
+
+    @Override
+    public Map readFrom(MultivaluedMap<String, String> httpHeaders,
+            InputStream entityStream) throws IOException,
+            WebApplicationException {
+        // TODO: Fix MessageBodyReaderSupport abstract method (remove it completely or add empty implementation?)
+        throw new RuntimeException("This should never be called, because we override the readFrom(all-parameters) method.");
     }
 }

--- a/src/java/org/grails/jaxrs/provider/XMLReader.java
+++ b/src/java/org/grails/jaxrs/provider/XMLReader.java
@@ -20,15 +20,19 @@ import static org.grails.jaxrs.support.ConverterUtils.xmlToMap;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
 import java.util.Map;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.Provider;
 
 import org.codehaus.groovy.grails.commons.GrailsApplication;
 import org.codehaus.groovy.grails.plugins.support.aware.GrailsApplicationAware;
+import org.grails.jaxrs.support.ConverterUtils;
 import org.grails.jaxrs.support.MessageBodyReaderSupport;
 
 /**
@@ -68,24 +72,23 @@ public class XMLReader extends MessageBodyReaderSupport<Map> implements GrailsAp
         this.grailsApplication = grailsApplication;
     }
 
-    /**
-     * Creates a map from an XML request entity stream.
-     *
-     * @param httpHeaders
-     *            HTTP headers.
-     * @param entityStream
-     *            XML request entity stream.
-     * @return a map representation of the XML request entity stream.
-     * @see ConverterUtils#xmlToMap(InputStream, String)
-     */
     @Override
-    public Map readFrom(MultivaluedMap<String, String> httpHeaders, InputStream entityStream)
-        throws IOException, WebApplicationException {
-
-        // TODO: obtain encoding from HTTP header and/or XML document
-        String encoding = getDefaultEncoding(grailsApplication);
+    public Map readFrom(Class<Map> type, Type genericType,
+            Annotation[] annotations, MediaType mediaType,
+            MultivaluedMap<String, String> httpHeaders, InputStream entityStream)
+            throws IOException, WebApplicationException {
+        
+        String encoding = ConverterUtils.getEncoding(httpHeaders, mediaType, getDefaultEncoding(grailsApplication));
 
         // Convert XML to map used for constructing domain objects
         return xmlToMap(entityStream, encoding);
+    }
+
+    @Override
+    public Map readFrom(MultivaluedMap<String, String> httpHeaders,
+            InputStream entityStream) throws IOException,
+            WebApplicationException {
+        // TODO: Fix MessageBodyReaderSupport abstract method
+        throw new RuntimeException("This should never be called, because we override the readFrom(all-parameters) method.");
     }
 }

--- a/test/integration/org/grails/jaxrs/itest/JaxrsControllerIntegrationTests.groovy
+++ b/test/integration/org/grails/jaxrs/itest/JaxrsControllerIntegrationTests.groovy
@@ -21,6 +21,9 @@ import org.junit.Test
 
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertTrue
+import java.nio.charset.Charset;
+
+import java.util.List;
 
 /**
  * @author Martin Krasser
@@ -76,6 +79,16 @@ abstract class JaxrsControllerIntegrationTests extends IntegrationTestCase {
     }
 
     @Test
+    void testPost03_CustomCharset() {
+        String CUSTOM_CHARSET = 'UTF-16'
+        sendRequest('/test/03', 'POST', ['Content-Type':"application/json; charset=${CUSTOM_CHARSET}".toString()], '{"class":"TestPerson","age":38,"name":"mike"}'.getBytes(CUSTOM_CHARSET))
+        assertEquals(200, response.status)
+        assertTrue(response.contentAsString.contains('"age":39'))
+        assertTrue(response.contentAsString.contains('"name":"ekim"'))
+        assertTrue(response.getHeader('Content-Type').startsWith('application/json'))
+    }
+    
+    @Test
     void testRoundtrip04XmlSingle() {
         def headers = ['Content-Type': 'application/xml', 'Accept': 'application/xml']
         sendRequest('/test/04/single', 'POST', headers, '<testPerson><name>james</name></testPerson>'.bytes)
@@ -92,6 +105,33 @@ abstract class JaxrsControllerIntegrationTests extends IntegrationTestCase {
         assertTrue(response.contentAsString.contains('"age":26'))
         assertTrue(response.contentAsString.contains('"name":"semaj"'))
         assertTrue(response.getHeader('Content-Type').startsWith('application/json'))
+    }
+    
+    @Test
+    void testRoundtrip04JsonSingle_CustomCharset() {
+        String CUSTOM_CHARSET = 'UTF-16'
+        def headers = ['Content-Type':"application/json; charset=${CUSTOM_CHARSET}".toString(), 'Accept':'application/json']
+        def testPersonWithCustomEncoding = '{"class":"TestPerson","age":45,"name":"james"}'.getBytes(Charset.forName(CUSTOM_CHARSET))
+        
+        sendRequest('/test/04/single', 'POST', headers, testPersonWithCustomEncoding)
+        
+        assertEquals(200, response.status)
+        assertTrue(response.contentAsString.contains('"age":46'))
+        assertTrue(response.contentAsString.contains('"name":"semaj"'))
+               assertTrue(response.getHeader('Content-Type').startsWith('application/json'))
+    }
+    
+    @Test
+    void testRoundtrip04XmlSingle_CustomCharset() {
+        String CUSTOM_CHARSET = 'UTF-16'
+        def headers = ['Content-Type':"application/xml; charset=${CUSTOM_CHARSET}".toString(), 'Accept':'application/xml']
+        byte[] testPersonWithCustomEncoding = '<testPerson><name>james</name></testPerson>'.getBytes(Charset.forName(CUSTOM_CHARSET))
+        
+        sendRequest('/test/04/single', 'POST', headers, testPersonWithCustomEncoding)
+        
+        assertEquals(200, response.status)
+        assertTrue(response.contentAsString.contains('<name>semaj</name>'))
+        assertTrue(response.getHeader('Content-Type').startsWith('application/xml'))
     }
 
     @Test


### PR DESCRIPTION
Hi,

I have implemented support for handing charset encoding, if specified in HTTP headers. I also added a few tests to verify this improvement and that pass succesfully.

I have rebased my original patch on top of master branch, as we are now migrating our app to grails 2.2.x

Best regards,
Dumitru Postoronca
