### PR TITLE
Grails 2.4 fixes -- Use Holders class to access grailsApplication

### DIFF
--- a/src/groovy/org/grails/jaxrs/itest/IntegrationTestCase.groovy
+++ b/src/groovy/org/grails/jaxrs/itest/IntegrationTestCase.groovy
@@ -48,9 +48,9 @@ abstract class IntegrationTestCase implements JaxRsIntegrationTest {
     @Before
     void setUp() {
         autowirer.autowire(this)
-        grailsApplication.config.org.grails.jaxrs.dowriter.require.generic.collections = false
-        grailsApplication.config.org.grails.jaxrs.doreader.disable = false
-        grailsApplication.config.org.grails.jaxrs.dowriter.disable = false
+        Holders.grailsApplication.config.org.grails.jaxrs.dowriter.require.generic.collections = false
+        Holders.grailsApplication.config.org.grails.jaxrs.doreader.disable = false
+        Holders.grailsApplication.config.org.grails.jaxrs.dowriter.disable = false
 
         controller = new JaxrsController()
         defaultMixin = new JaxRsIntegrationTestMixin(controller)


### PR DESCRIPTION
Updated IntegrationTestCase to use the new Holders class to access grailsApplication so that it runs on Grails 2.4.
